### PR TITLE
Fix: iOS 5.1.1 - non-english symbols in hash

### DIFF
--- a/common.blocks/i-jquery/__history/i-jquery__history.js
+++ b/common.blocks/i-jquery/__history/i-jquery__history.js
@@ -587,7 +587,7 @@
                 // Fix Safari Bug https://bugs.webkit.org/show_bug.cgi?id=56249
                 History.pushState(null, null, $.url.getPage() + hashBang  + adjustedHash, false);
             } else {
-                $.url.setHash(hashBang + adjustedHash);
+                $.url.setHash(hashBang + hash);
             }
         }
 


### PR DESCRIPTION
Author: @L0stSoul
