### PR TITLE
Return deep copy of state

### DIFF
--- a/common.blocks/i-location/i-location.js
+++ b/common.blocks/i-location/i-location.js
@@ -129,7 +129,7 @@
          * @returns {object} state
          */
         getState : function() {
-            return this._state;
+            return $.extend(true, {}, this._state);
         }
 
     }, {


### PR DESCRIPTION
_state is private var, so a copy of it should be returned. Otherwise undesirable modifications can happen. E.g. 
$.extend(BEM.blocks['i-location'].get().getState().params, myParams)
will affect _state.
