### PR TITLE
Fix for urls with port

### DIFF
--- a/common.blocks/i-jquery/__url/i-jquery__url.js
+++ b/common.blocks/i-jquery/__url/i-jquery__url.js
@@ -45,7 +45,7 @@
          */
         getRoot : function() {
 
-            return location.protocol + '//' + (location.hostname || location.host) + '/';
+            return location.protocol + '//' + (location.hostname || location.host) + (location.port ? ':' + location.port : '') + '/';
 
         },
 


### PR DESCRIPTION
В текущей реализации при нормализации урла не учитывался текущий порт. Фикс этой проблемы.
