### PR TITLE
Do not remove an anchor without hasbang on history init

### DIFF
--- a/common.blocks/history/_provider/history_provider_history-api.spec.js
+++ b/common.blocks/history/_provider/history_provider_history-api.spec.js
@@ -4,12 +4,6 @@ describe('history native API', function() {
     
     var history = new History();
     
-    it('should be able to remove hashbang from url', function() {
-        var url = history._removeHashbang('/desktop.bundles/index/index.html?ololo=trololo#!/index.html?test=a&ololo=123'),
-            checkUrl = Uri.parse('/desktop.bundles/index/index.html?test=a&ololo=123');
-        url.should.be.eql(checkUrl.build());
-    });
-    
     it('should have _onPopState method', function() {
         history._onPopState.should.be.a('function');
     });

--- a/common.blocks/history/history.js
+++ b/common.blocks/history/history.js
@@ -71,10 +71,11 @@ var BEMHistory = inherit(events.Emitter, {
      * @returns {String}
      */
     _removeHashbang : function(url) {
-        var parsedUri = Uri.parse(url);
+        var parsedUri = Uri.parse(url),
+            hash = parsedUri.getAnchor();
 
-        if(parsedUri.getAnchor() === '') { return url; }
-        var hashbangUri = Uri.parse(parsedUri.getAnchor().replace(/^!/, ''));
+        if(hash === '' || hash[0] !== '!') { return url; }
+        var hashbangUri = Uri.parse(hash.replace(/^!/, ''));
 
         parsedUri
             .setAnchor('')

--- a/common.blocks/history/history.spec.js
+++ b/common.blocks/history/history.spec.js
@@ -1,4 +1,4 @@
-modules.define('spec', ['jquery', 'history'], function(provide, $, History) {
+modules.define('spec', ['jquery', 'history', 'uri'], function(provide, $, History, Uri) {
 
 describe('history', function() {
     
@@ -14,6 +14,17 @@ describe('history', function() {
     
     it('should have changeState method', function() {
         history.changeState.should.be.a('function');
+    });
+    
+    it('should be able to remove hashbang from url', function() {
+        var url = history._removeHashbang('/desktop.bundles/index/index.html?ololo=trololo#!/index.html?test=a&ololo=123'),
+            checkUrl = Uri.parse('/desktop.bundles/index/index.html?test=a&ololo=123');
+        url.should.be.eql(checkUrl.build());
+    });
+    
+    it('should not remove anchor hash without #! from url', function() {
+        var url = history._removeHashbang('/desktop.bundles/index/index.html?test=a&ololo=123#anchor');
+        url.should.be.eql('/desktop.bundles/index/index.html?test=a&ololo=123#anchor');
     });
 
 });


### PR DESCRIPTION
Now removes only hashbang (#!...), hash (#anchor) leaves intact
