### PR TITLE
Ошибка в методе deleteParam в случае отсутствия нужного параметра

### DIFF
--- a/common.blocks/uri/uri.js
+++ b/common.blocks/uri/uri.js
@@ -205,7 +205,7 @@ BEM.decl('uri', {
         var newParams = [];
 
         if (typeof val !== 'undefined') {
-            this.queryParams[key].forEach(function(paramValue) {
+            (this.queryParams[key] || []).forEach(function(paramValue) {
                 if (paramValue !== val) {
                     newParams.push(paramValue);
                 }


### PR DESCRIPTION
Если параметра, который хотим удалить, в урле нет, то forEach вызывается у undefined.
