### PR TITLE
«Расслабил» зависимость от bem-core

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "*.bundles"
   ],
   "dependencies": {
-    "bem-core": "2.6.0"
+    "bem-core": "^2.6.0"
   },
   "devDependencies": {
     "bem-pr": "0.11.0"


### PR DESCRIPTION
С выходом `bem-core#2.7.0` бовер начала с падать от невозможности разрешить, какую версию использовать (бовер запускается в неинтерактивном режиме как пост-инсталл скрипт для `npm i`).

Мне кажется, что фиксации на мажорной версии должно быть достаточно.
