### PR TITLE
Кодируем пустой параметр, переданный в Uri.addParam()

### DIFF
--- a/common.blocks/uri/uri.js
+++ b/common.blocks/uri/uri.js
@@ -171,7 +171,7 @@ Uri.prototype.getQuery = function(val) {
             s += '&';
         }
         if(typeof params[key] === 'object' && !params[key].length) {
-            s += key;
+            s += _this.encode(key);
         } else {
             params[key].forEach(function(v, i) {
                 if(i > 0) {

--- a/common.blocks/uri/uri.spec.js
+++ b/common.blocks/uri/uri.spec.js
@@ -78,6 +78,12 @@ describe('uri', function() {
         u.toString().should.be.eql('http://test.com/index.html?param');
     });
 
+    it('should encode empty param', function() {
+        u = Uri.parse('http://test.com/index.html');
+        u.addParam('param[]', []);
+        u.toString().should.be.eql('http://test.com/index.html?param%5B%5D');
+    });
+
     it('should add a query to nothing', function() {
         u = Uri.parse('');
         u.setQuery('this=that&something=else');


### PR DESCRIPTION
Если вызвать `uri.addParam('search[direction][]', [])` (например, через location.change({}), то строковое представление будет `http://test.com/index.html?search[direction][]` вместо ожидаемого `http://test.com/index.html?search%5Bdirection%5D%5B%5D`.
