### PR TITLE
Option "silent" for location didn't work

### DIFF
--- a/common.blocks/history/_provider/history_provider_history-api.js
+++ b/common.blocks/history/_provider/history_provider_history-api.js
@@ -33,7 +33,7 @@ provide(inherit(Base, /** @lends history.prototype */{
 
         // Remove silent param to fix back-forward buttons work
         // after location silent=true flag usage
-        this.state.data && delete this.state.data.silent;
+        delete this.state.silent;
 
         this.emit('statechange', { state : state, nativeApi : true });
     },

--- a/common.blocks/location/location.js
+++ b/common.blocks/location/location.js
@@ -51,7 +51,7 @@ var BEMLocation = inherit(events.Emitter, /** @lends BEMLocation.prototype */{
         var state = this._history.state,
             uri = Uri.parse(state.url);
 
-        this._state = objects.extend(state.data, {
+        this._state = objects.extend(state, {
             referer : this._state && this._state.url, // referer - previous url
             url : uri.build(),                        // full page URL –
             // http://yandex.ru/yandsearch?text=ololo&lr=213

--- a/common.blocks/location/location.spec.js
+++ b/common.blocks/location/location.spec.js
@@ -1,4 +1,4 @@
-modules.define('spec', ['uri', 'location'], function(provide, Uri, location) {
+modules.define('spec', ['uri', 'location', 'sinon'], function(provide, Uri, location, sinon) {
 
 describe('location native API', function() {
 
@@ -20,6 +20,42 @@ describe('location native API', function() {
             (u.getPath() + u.getQuery()).should.be.eql('/desktop.specs/location/spec-js+browser-js+bemhtml/spec-js+browser-js+bemhtml.html?test=1&test=2&param2=22');
         });
 
+        it('shouldn\'t emit "change" event when silent option passed', function() {
+            var spy = sinon.spy();
+            var url1 = '/desktop.specs/location/spec-js+browser-js+bemhtml/spec-js+browser-js+bemhtml.html?test=a';
+            var url2 = '/desktop.specs/location/spec-js+browser-js+bemhtml/spec-js+browser-js+bemhtml.html?test=b';
+            location.on('change', spy);
+            location.change({
+                url : url1,
+                silent : true
+            });
+            location.change({
+                url : url2
+            });
+
+            spy.should.have.been.calledOnce;
+        });
+
+        it.skip('should emit "change" event when back button pressed', function() {
+            // Этот тест будет возможно запускать только на phantomjs2. В 1.9.х не эмитится событие popstate
+            // https://github.com/ariya/phantomjs/issues/11738
+            var spy = sinon.spy();
+            var url1 = '/desktop.specs/location/spec-js+browser-js+bemhtml/spec-js+browser-js+bemhtml.html?test=a';
+            var url2 = '/desktop.specs/location/spec-js+browser-js+bemhtml/spec-js+browser-js+bemhtml.html?test=b';
+            location.on('change', spy);
+            location.change({
+                url : url1,
+                silent : true
+            });
+            location.change({
+                url : url2,
+                silent : true
+            });
+
+            window.history.back();
+
+            spy.should.have.been.calledOnce;
+        });
 });
 
 provide();


### PR DESCRIPTION
We was needed for silent change location. But it didn't work:

```
location.change({url: 'some url', silent: true});
```

Event "change" was still emitted.

If I pass `{url: 'some url', {data: {silent: true } }` It works, but It looks strange and doesn't match with jsDoc.
