### PR TITLE
Corrected uri parser regular expression

### DIFF
--- a/common.blocks/uri/uri.js
+++ b/common.blocks/uri/uri.js
@@ -13,8 +13,6 @@
  * Released under the MIT license.
  */
 
-/* jshint maxlen:170 */
-
 /**
  * @module uri
  */
@@ -81,11 +79,7 @@ Uri.prototype.normalize = function(str) {
 * @returns {Object}    parts
 */
 Uri.prototype.parseUri = function(str) {
-    /*
-    DO NOT split parser regex into parts because it can seriously affect performance!
-    jsHint maxlen changed to fix maxlength warning at this line.
-    */
-    var parser = /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+    var parser = /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@\/]*)(?::([^:@\/]*))?)?@)?(\[[0-9a-fA-F:.]+\]|[^:\/?#]*)(?::(\d+|(?=:)))?:?)((((?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/, /* jshint ignore:line */
         parserKeys = ['source', 'protocol', 'authority',
                       'userInfo', 'user', 'password', 'host', 'port',
                       'relative', 'path', 'directory', 'file', 'query', 'anchor'],

--- a/common.blocks/uri/uri.spec.js
+++ b/common.blocks/uri/uri.spec.js
@@ -210,7 +210,12 @@ describe('uri', function() {
         u = Uri.parse('http://test.com/ololo/trololo.html?text=%COCO%C0C0');
         u.getParam('text')[0].should.be.eql('%COCO%C0C0');
     });
-    
+
+    it('should correctly parse url with query containing "@"', function() {
+        u = Uri.parse('http://example.com/?text=@fake.com');
+        u.toString().should.be.eql('http://example.com/?text=%40fake.com');
+    });
+
     it('should be able to normalize a full url to percentage encoding', function() {
         Uri
             .normalize('http://yandex.ru/yandsearch?text=yandex+почта&lr=213')


### PR DESCRIPTION
URI parsing regular expression incorrectly parses uris like `http://example.com/?text=@fake.com` as `http://fake.com`. It seems due to outdated regular expression, so I've updated it from [jsUri](https://github.com/derek-watson/jsUri/blob/master/Uri.js#L29) referenced inside the code. Comparing to the original I removed `isColonUri` group, since it isn't used here.

P.S. Tests are failing for me in the main branch as well.
